### PR TITLE
Fix retain cycles with LinkedTreeMap.EntrySet and KeySet

### DIFF
--- a/employee-gson/src/main/java/com/google/gson/internal/LinkedTreeMap.java
+++ b/employee-gson/src/main/java/com/google/gson/internal/LinkedTreeMap.java
@@ -458,7 +458,7 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
     }
 
     /** Create a regular entry */
-    Node(Node<K, V> parent, K key, @Weak Node<K, V> next, @Weak Node<K, V> prev) {
+    Node(Node<K, V> parent, K key, Node<K, V> next, Node<K, V> prev) {
       this.parent = parent;
       this.key = key;
       this.height = 1;

--- a/employee-gson/src/main/java/com/google/gson/internal/LinkedTreeMap.java
+++ b/employee-gson/src/main/java/com/google/gson/internal/LinkedTreeMap.java
@@ -18,6 +18,7 @@
 package com.google.gson.internal;
 
 import com.google.j2objc.annotations.Weak;
+import com.google.j2objc.annotations.WeakOuter;
 
 import java.io.ObjectStreamException;
 import java.io.Serializable;
@@ -562,6 +563,7 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
     }
   }
 
+  @WeakOuter
   class EntrySet extends AbstractSet<Entry<K, V>> {
     @Override public int size() {
       return size;
@@ -597,6 +599,7 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
     }
   }
 
+  @WeakOuter
   final class KeySet extends AbstractSet<K> {
     @Override public int size() {
       return size;


### PR DESCRIPTION
The EntrySet and KeySet inner classes were retaining the LinkedTreeMap instance. The LinkedTreeMap keeps strong references to one instance of each (created lazily as needed), so the inner class instances cannot outlive the parent class, and thus we can use `@WeakOuter` to prevent this retain cycle.

Note: I haven’t checked in the translated sources to avoid many trivial line changes (e.g. local file paths).
